### PR TITLE
stop ccache workers when flushing cache

### DIFF
--- a/cache/config.go
+++ b/cache/config.go
@@ -47,6 +47,9 @@ func (c *Config) FlushCache(serviceName string) {
 	c.caches.Range(func(k, v interface{}) bool {
 		cacheName := k.(string)
 		if strings.HasPrefix(cacheName, serviceName) {
+			o, _ := c.caches.Load(cacheName)
+			ccacheInstance := o.(*ccache.Cache)
+			ccacheInstance.Stop()
 			c.caches.Store(cacheName, ccache.New(ccache.Configure()))
 			n := strings.Split(cacheName, ".")
 			c.incFlush(n[0], n[1])

--- a/cache/config.go
+++ b/cache/config.go
@@ -17,8 +17,9 @@ import (
 type Config struct {
 	DefaultTTL  time.Duration
 	specificTTL map[string]time.Duration
-	caches      *sync.Map
-	metrics     *cacheCollector
+	sync.RWMutex
+	caches  *sync.Map
+	metrics *cacheCollector
 }
 
 const cacheNameFormat = "%v.%v"
@@ -47,10 +48,12 @@ func (c *Config) FlushCache(serviceName string) {
 	c.caches.Range(func(k, v interface{}) bool {
 		cacheName := k.(string)
 		if strings.HasPrefix(cacheName, serviceName) {
+			c.Lock()
 			o, _ := c.caches.Load(cacheName)
 			ccacheInstance := o.(*ccache.Cache)
-			ccacheInstance.Stop()
 			c.caches.Store(cacheName, ccache.New(ccache.Configure()))
+			ccacheInstance.Stop()
+			c.Unlock()
 			n := strings.Split(cacheName, ".")
 			c.incFlush(n[0], n[1])
 		}
@@ -83,10 +86,15 @@ func (c *Config) getCache(r *request.Request) *ccache.Cache {
 }
 
 func (c *Config) get(r *request.Request) *ccache.Item {
+	c.RLock()
+	defer c.RUnlock()
 	return c.getCache(r).Get(cacheKey(r))
 }
 
 func (c *Config) set(r *request.Request, object interface{}) {
+	c.RLock()
+	defer c.RUnlock()
+
 	if !isCachable(r.Operation.Name) {
 		return
 	}


### PR DESCRIPTION
It seems there is a goroutine leak from `github.com/karlseguin/ccache.(*Cache).worker+0xc5` whenever the cache is flushed.

From my testing, this seem to happen because the associated goroutines are not stopped before replacing the cache in the store with a new one.

From ccache docs
```
Stop
The cache's background worker can be stopped by calling Stop.
Once Stop is called the cache should not be used (calls are likely to panic).
Stop must be called in order to allow the garbage collector to reap the cache.
```

To reproduce this bug all you need to do is make a call in a loop for a non cacheable call.
In my case I am using `elbv2.DeregisterTargets` - which will flush on every call (because its non cacheable), when you examine the goroutine count they keep going up and never get released.

With this change I no longer notice this behavior.