### PR TITLE
Selective Flushing on Writes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-sdk-go v1.15.39 h1:MUxm375zGxxVhgL5NNCIDuwn4SkMQsX8CQWD+zLULc
 github.com/aws/aws-sdk-go v1.15.39/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.16.35 h1:qz1h7uxswkVaE6kJPoPWwt3F76HlCLrg/UyDJq3cavc=
 github.com/aws/aws-sdk-go v1.16.35/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.27.3 h1:CBWC7Yot0U6OU/uosUmq7tKJVBTq6HrhgW1Vjpt9SMw=
+github.com/aws/aws-sdk-go v1.27.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -14,6 +16,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/karlseguin/ccache v2.0.2+incompatible h1:MpSlLlHgG3vPWTAIJsSYlyAQsHwfQ2HzgUlbJFh9Ufk=
 github.com/karlseguin/ccache v2.0.2+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=


### PR DESCRIPTION
Currently, when a write is made, it will flush all service caches.
For example, a call to `elasticloadbalancing.DescribeTargetHealth` will cache, and a subsequent call to `elasticloadbalancing.DeregisterTarget` (an non-cacheable write) would flush all caches under `elasticloadbalancing`.

This behavior might be inappropriate if the write is irrelevant to other reads.
In the above case for example, I do not want `DeregisterTargets` to flush all my caches for `elasticloadbalancing`.

This is further relevant when considering that `elb` and `elbv2` are both using service name `elasticloadbalancing`.

This PR adds a map of `mutatingCaches` which can define which write operations are `mutating` and we should flush when they are called.

By default, all writes are considered mutating (to have same behavior as now), however one could choose to exclude a specific operation from this behavior by using `SetCacheMutating(serviceName, operationName, false)` => this will mark the specific operation as non-mutating.
In this case we will only flush the operation cache i.e. discard that write cache instead of flushing all service caches

This can really improve cache hit/miss in some scenarios.